### PR TITLE
Define durable object and update worker name

### DIFF
--- a/cloudflare-worker/src/SearxngContainer.ts
+++ b/cloudflare-worker/src/SearxngContainer.ts
@@ -2,7 +2,7 @@ import { Container } from "@cloudflare/containers";
 
 export class SearxngContainer extends Container {
   defaultPort = 8080;     // uwsgi inside the official image
-  sleepAfter  = "5m";     // mirrors wrangler.toml
+  sleepAfter  = "5m";     // keep container warm for 5 minutes
 
   // optional safety-net: ensure Python finished booting
   async onStart() {

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -17,3 +17,5 @@ export default {
     return searx.fetch(request);
   }
 };
+
+export { SearxngContainer };

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,6 +1,15 @@
-name = "searxng-worker"
+name = "searxng-docker"
 main = "src/index.ts"
 compatibility_date = "2025-08-03"
+
+[durable_objects]
+bindings = [
+  { name = "SEARXNG", class_name = "SearxngContainer" }
+]
+
+[[migrations]]
+tag = "v1"
+new_classes = ["SearxngContainer"]
 
 [[containers]]
 name = "searxng"
@@ -11,5 +20,4 @@ image = "ghcr.io/searxng/searxng:latest"
 # https://developers.cloudflare.com/containers/platform-details/
 instance_type = "basic"
 max_instances = 1
-sleep_after = "5m"
 


### PR DESCRIPTION
## Summary
- rename Cloudflare worker to `searxng-docker`
- add `SEARXNG` durable object binding with initial migration
- export `SearxngContainer` and drop unsupported `sleep_after` config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run cf-typegen`
- `npx wrangler deploy --dry-run` *(fails: Not logged in)*

------
https://chatgpt.com/codex/tasks/task_e_688fbb86dd088328bcd0c80d9073a988